### PR TITLE
Fixing --ytdl-format configuration

### DIFF
--- a/piptube.py
+++ b/piptube.py
@@ -89,8 +89,7 @@ class PlayVideo:
 
     def play_url(self):
         subprocess.run([*self.mpv,
-                        '--ytdl-format',
-                        self.video_format,
+                        f'--ytdl-format={self.video_format}',
                         self.source])
 
     def play_search(self):


### PR DESCRIPTION
I try to use your program and that erros was happening
```
Error parsing commandline option ytdl-format: option requires parameter
Make sure you're using e.g. '--ytdl-format=value' instead of '--ytdl-format value'.
Exiting... (Fatal error)
```
So I made that change.